### PR TITLE
Switch messageType type to @vocab

### DIFF
--- a/v1p1/caliper-v1p1-profile-toollaunch-extension.jsonld
+++ b/v1p1/caliper-v1p1-profile-toollaunch-extension.jsonld
@@ -4,13 +4,13 @@
 
     "Link": "caliper:Link",
     "LtiLink": "caliper:LtiLink",
-    "LtiDeepLinkingRequest": "caliper:LtiDeepLinkingRequest",
-    "LtiResourceLinkRequest": "caliper:LtiResourceLinkRequest",
 
-    "messageType": {"@id": "caliper:messageType", "@type": "@id"},    
+    "messageType": {"@id": "caliper:messageType", "@type": "@vocab"},
 
     "Launched": "caliper:actions/Launched",
-    "Returned": "caliper:actions/Returned"    
+    "Returned": "caliper:actions/Returned",
 
+    "LtiDeepLinkingRequest": "caliper:LtiDeepLinkingRequest",
+    "LtiResourceLinkRequest": "caliper:LtiResourceLinkRequest"
   }]
 }


### PR DESCRIPTION
Switch the messageType definition from 

"messageType": {"@id": "caliper:messageType", "@type": "@id"},
to
"messageType": {"@id": "caliper:messageType", "@type": "@vocab"},

which indicates that the values of the `messageType` are to be found in the JSON-LD context, in this case,

"LtiDeepLinkingRequest": "caliper:LtiDeepLinkingRequest",
"LtiResourceLinkRequest": "caliper:LtiResourceLinkRequest"