### PR TITLE
Add storage name property to context (cc207)

### DIFF
--- a/v1p2/caliper-v1p2.jsonld
+++ b/v1p2/caliper-v1p2.jsonld
@@ -153,6 +153,7 @@
     "selectionText": {"@id": "caliper:selectionText", "@type": "xsd:string"},
     "start": {"@id": "caliper:start", "@type": "xsd:nonNegativeInteger"},
     "startedAtTime": {"@id": "caliper:startedAtTime", "@type": "xsd:dateTime"},
+    "storageName": {"@id": "caliper:storageName", "@type": "xsd:string"},
     "value": {"@id": "caliper:value", "@type": "xsd:string"},
     "version": {"@id": "caliper:version", "@type": "xsd:string"},
     "volumeLevel": {"@id": "caliper:volumeLevel", "@type": "xsd:string"},


### PR DESCRIPTION
Adds a storage name property for use on DigitalResource; see also:

- https://github.com/IMSGlobal/caliper-central/issues/207
- https://github.com/IMSGlobal/caliper-common-fixtures/pull/218