### PR TITLE
Add in extension context for ToolUse for progress (cc202)

### DIFF
--- a/v1p1/caliper-v1p1-profile-tooluse-extension.jsonld
+++ b/v1p1/caliper-v1p1-profile-tooluse-extension.jsonld
@@ -4,8 +4,8 @@
     "AggregateMeasure": "caliper:AggregateMeasure",
 
     "metric": {"@id": "caliper:metric", "@type": "@vocab"},
-    "progressValue": {"@id": "caliper:progressValue", "@type": "xsd:decimal"},
-    "progressValueMax": {"@id": "caliper:progressValueMax", "@type": "xsd:decimal"},
+    "metricValue": {"@id": "caliper:metricValue", "@type": "xsd:decimal"},
+    "metricValueMax": {"@id": "caliper:metricValueMax", "@type": "xsd:decimal"},
 
     "ActivitiesCompleted": "caliper:ActivitiesCompleted",
     "ActivitiesPassed": "caliper:ActivitiesPassed",

--- a/v1p1/caliper-v1p1-profile-tooluse-extension.jsonld
+++ b/v1p1/caliper-v1p1-profile-tooluse-extension.jsonld
@@ -7,18 +7,13 @@
     "metricValue": {"@id": "caliper:metricValue", "@type": "xsd:decimal"},
     "metricValueMax": {"@id": "caliper:metricValueMax", "@type": "xsd:decimal"},
 
-    "ActivitiesCompleted": "caliper:ActivitiesCompleted",
-    "ActivitiesPassed": "caliper:ActivitiesPassed",
-    "AssessmentsCompleted": "caliper:AssessmentsCompleted",
+    "AssessmentsSubmitted": "caliper:AssessmentsSubmitted",
     "AssessmentsPassed": "caliper:AssessmentsPassed",
-    "DocumentsRead": "caliper:DocumentsRead",
-    "LessonsCompleted": "caliper:LessonsCompleted",
-    "LessonsPased": "caliper:LessonsPassed",
     "MinutesOnTask": "caliper:MinutesOnTask",
+    "SkillsMastered": "caliper:SkillsMastered",
     "StandardsMastered": "caliper:StandardsMastered",
     "UnitsCompleted": "caliper:UnitsCompleted",
     "UnitsPassed": "caliper:UnitsPassed",
-    "WordsRead": "caliper:WordsRead",
-    "WordsWritten": "caliper:WordsWritten"
+    "WordsRead": "caliper:WordsRead"
   }]
 }

--- a/v1p1/caliper-v1p1-profile-tooluse-extension.jsonld
+++ b/v1p1/caliper-v1p1-profile-tooluse-extension.jsonld
@@ -1,0 +1,23 @@
+{
+  "@context": ["http://purl.imsglobal.org/ctx/caliper/v1p1", {
+
+    "AggregateMeasure": "caliper:AggregateMeasure",
+
+    "metric": {"@id": "caliper:metric", "@type": "@vocab"},
+    "progressValue": {"@id": "caliper:progressValue", "@type": "xsd:decimal"},
+
+    "ActivitiesCompleted": "caliper:ActivitiesCompleted",
+    "ActivitiesPassed": "caliper:ActivitiesPassed",
+    "AssessmentsCompleted": "caliper:AssessmentsCompleted",
+    "AssessmentsPassed": "caliper:AssessmentsPassed",
+    "DocumentsRead": "caliper:DocumentsRead",
+    "LessonsCompleted": "caliper:LessonsCompleted",
+    "LessonsPased": "caliper:LessonsPassed",
+    "MinutesOnTask": "caliper:MinutesOnTask",
+    "StandardsMastered": "caliper:StandardsMastered",
+    "UnitsCompleted": "caliper:UnitsCompleted",
+    "UnitsPassed": "caliper:UnitsPassed",
+    "WordsRead": "caliper:WordsRead",
+    "WordsWritten": "caliper:WordsWritten"
+  }]
+}

--- a/v1p1/caliper-v1p1-profile-tooluse-extension.jsonld
+++ b/v1p1/caliper-v1p1-profile-tooluse-extension.jsonld
@@ -5,6 +5,7 @@
 
     "metric": {"@id": "caliper:metric", "@type": "@vocab"},
     "progressValue": {"@id": "caliper:progressValue", "@type": "xsd:decimal"},
+    "progressValueMax": {"@id": "caliper:progressValueMax", "@type": "xsd:decimal"},
 
     "ActivitiesCompleted": "caliper:ActivitiesCompleted",
     "ActivitiesPassed": "caliper:ActivitiesPassed",


### PR DESCRIPTION
This adds a ToolUse-extension context for capturing the progress stuff added in extension to ToolUse against 1.1.

See also:
- https://github.com/IMSGlobal/caliper-central/issues/202
- https://github.com/IMSGlobal/caliper-central/issues/211

