### PR TITLE
Change IRI of Metric enums to include /metrics/ in order to align with current practice; add AggregateMeasureCollection

### DIFF
--- a/v1p1/caliper-v1p1-tooluseprofile-extension.jsonld
+++ b/v1p1/caliper-v1p1-tooluseprofile-extension.jsonld
@@ -2,18 +2,19 @@
   "@context": ["http://purl.imsglobal.org/ctx/caliper/v1p1", {
 
     "AggregateMeasure": "caliper:AggregateMeasure",
+    "AggregateMeasureCollection": "caliper:AggregateMeasureCollection",
 
+    "maxMetricValue": {"@id": "caliper:maxMetricValue", "@type": "xsd:decimal"},
     "metric": {"@id": "caliper:metric", "@type": "@vocab"},
     "metricValue": {"@id": "caliper:metricValue", "@type": "xsd:decimal"},
-    "metricValueMax": {"@id": "caliper:metricValueMax", "@type": "xsd:decimal"},
 
-    "AssessmentsSubmitted": "caliper:AssessmentsSubmitted",
-    "AssessmentsPassed": "caliper:AssessmentsPassed",
-    "MinutesOnTask": "caliper:MinutesOnTask",
-    "SkillsMastered": "caliper:SkillsMastered",
-    "StandardsMastered": "caliper:StandardsMastered",
-    "UnitsCompleted": "caliper:UnitsCompleted",
-    "UnitsPassed": "caliper:UnitsPassed",
-    "WordsRead": "caliper:WordsRead"
+    "AssessmentsSubmitted": "caliper:metrics/AssessmentsSubmitted",
+    "AssessmentsPassed": "caliper:metrics/AssessmentsPassed",
+    "MinutesOnTask": "caliper:metrics/MinutesOnTask",
+    "SkillsMastered": "caliper:metrics/SkillsMastered",
+    "StandardsMastered": "caliper:metrics/StandardsMastered",
+    "UnitsCompleted": "caliper:metrics/UnitsCompleted",
+    "UnitsPassed": "caliper:metrics/UnitsPassed",
+    "WordsRead": "caliper:metrics/WordsRead"
   }]
 }


### PR DESCRIPTION
Resolves #99.  

1.  Adds "/metrics/" to Metric enum IRIs.
2.  Changes `metricValueMax` to `maxMetricValue` (aligns with use of "max" prefix in other property names)
3.  Adds `AggregateMeasureCollection`

Note that `AggregateMeasureCollection` is being added in order to harmonize the JSON-LD context document with the ToolUse Profile as currently written.  We may amend, replace or drop `AggregateMeasureCollection` at a later date.