### PR TITLE
Add Collection entity to the context

### DIFF
--- a/v1p2/caliper-v1p2.jsonld
+++ b/v1p2/caliper-v1p2.jsonld
@@ -7,6 +7,7 @@
 
     "AggregateMeasure": "caliper:AggregateMeasure",
     "AggregateMeasureCollection": "caliper:AggregateMeasureCollection",
+    "Collection": "caliper:Collection",
     "Comment": "caliper:Comment",
     "LikertScale": "caliper:LikertScale",
     "Link": "caliper:Link",


### PR DESCRIPTION
- Adds a Collection entity term to the v1p2 context

- No change made to the `items` term that already exists in the v1p1 context;
  it's transcluded and available in the v1p2 context already

See also
- [Caliper central 218](https://github.com/IMSGlobal/caliper-central/issues/218)
